### PR TITLE
Refactor: Harden Node.js/browser env separation and API key handling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,19 @@ import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const geminiApiKey = env.GEMINI_API_KEY;
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        // Expose a flag indicating API key availability, not the key itself for client-side.
+        // The actual key will be picked up from the environment in Node.js contexts.
+        'process.env.GEMINI_API_KEY_AVAILABLE': JSON.stringify(!!geminiApiKey),
+        // For server-side code (like agentService when running in Node directly or Vite dev server),
+        // process.env.GEMINI_API_KEY will be used directly from the environment.
+        // This define below is more for consistency if some part of server-side code
+        // *during Vite's processing* tries to access it via `process.env.GEMINI_API_KEY`.
+        // The crucial part is that it's NOT exposed to the client bundle if not used.
+        // However, best practice is to rely on runtime environment variables for server-side.
+        // To be safe and explicit, we avoid defining process.env.GEMINI_API_KEY for client bundle.
       },
       resolve: {
         alias: {


### PR DESCRIPTION
- Modified `vite.config.ts` to avoid exposing GEMINI_API_KEY to the client. Instead, a flag `GEMINI_API_KEY_AVAILABLE` is set.
- Updated `services/agentService.ts`:
    - Gemini API calls are now strictly server-side (`typeof window === 'undefined'`)
    - Client-side calls to `processUserCommandViaAgent` will log a warning and return null.
    - API key is read from `process.env` on the server, not from Vite's `define`.
    - Updated Gemini API call structure for `@google/genai` SDK compatibility.
- Enhanced `services/ModuleLoaderService.ts`:
    - Added more granular try/catch blocks for dynamic imports of `fs`, `path`, `url` for better error diagnostics in Node.js environments.
    - Verified that existing guards correctly prevent Node.js module usage in the browser and handle their absence gracefully.
- Reviewed and confirmed Node.js specific code in `vite.config.ts` (e.g., `path`, `__dirname`) is appropriate as it runs in a Node environment.
- Ensured overall robustness, maintained public signatures, and improved code clarity in modified files.